### PR TITLE
Security: Command Injection via Unsanitized Input in build_docs.js

### DIFF
--- a/scripts/build_docs.js
+++ b/scripts/build_docs.js
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { existsSync, renameSync, rmSync, copyFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { downloadExternalSourceAssets } from "../src/ExternalSourceManager.js";
@@ -23,17 +23,17 @@ for (let i = 1; i <= currentMajorVersion; i+=1) {
 downloadExternalSourceAssets(join(docsDir, 'srcicons'));
 
 function downloadPackage(spec) {
-  const file = execSync(`npm pack "${spec}" --silent`, { encoding: "utf8" }).trim();
-  const folderName = file.replace(/\.tgz$/, "");
+  const file = execFileSync("npm", ["pack", spec, "--silent"], { encoding: "utf8" }).trim();
+  const folderNameDownloaded = file.replace(/\.tgz$/, "");
 
-  execSync(`tar -xzf "${file}"`, { stdio: "inherit" });
+  execFileSync("tar", ["-xzf", file], { stdio: "inherit" });
 
   if (!existsSync("package")) throw new Error("package/ folder not found after extraction.");
 
-  renameSync("package", folderName);
+  renameSync("package", folderNameDownloaded);
   rmSync(file);
 
-  return folderName;
+  return folderNameDownloaded;
 }
 
 function downloadLegacyIcons(majorVersion, targetDir) {
@@ -43,8 +43,8 @@ function downloadLegacyIcons(majorVersion, targetDir) {
   const iconDir = join(folderName, "dist", "icons");
   if (!existsSync(iconDir)) throw new Error(`dist/icons not found in ${folderName}`);
 
-  execSync(`cp -r "${iconDir}/." "${targetDir}"`);
-  execSync(`cp -r "${iconDir}/." "${join(docsDir, 'latest')}"`);
+  execFileSync("cp", ["-r", `${iconDir}/.`, targetDir]);
+  execFileSync("cp", ["-r", `${iconDir}/.`, join(docsDir, 'latest')]);
 
   if (majorVersion === currentMajorVersion) {
     copyFileSync(join(folderName, "package.json"), join(docsDir, 'package.json'));


### PR DESCRIPTION
## Summary

Security: Command Injection via Unsanitized Input in build_docs.js

## Problem

**Severity**: `High` | **File**: `scripts/build_docs.js:L27`

The `downloadPackage` function constructs an `npm pack` command using template literal interpolation with the `spec` parameter. The `downloadLegacyIcons` and `downloadLegacyFont` functions build this spec from `packageName` and `majorVersion` variables. While `majorVersion` is parsed as an integer, `packageName` comes from external configuration. More critically, the `execSync` calls use template literal interpolation which could be exploited if any variable is compromised. The `cp -r` command also uses unsanitized paths.

## Solution

Use `execFile` or `spawn` with array arguments to avoid shell interpretation. Validate and sanitize all path components before use in shell commands.

## Changes

- `scripts/build_docs.js` (modified)